### PR TITLE
fix: Ensure body background changes in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,8 +8,8 @@
 body {
     font-family: 'Arial', sans-serif;
     line-height: 1.6;
-    background-color: #f4f4f4; /* Default light background */
-    color: #333; /* Default text color */
+    background-color: var(--background-color); /* Use the variable */
+    color: var(--text-color); /* Use the variable for text too */
 }
 
 a {


### PR DESCRIPTION
I modified the main `body` CSS rule in `style.css` to use `var(--background-color)` for its background and `var(--text-color)` for its text color.

Previously, the body's background color was hardcoded, preventing it from updating when dark mode was activated. Card elements were changing as they already used CSS variables. This change ensures that the CSS variables defined in the `body.dark-mode` block for `--background-color` and `--text-color` are correctly applied to the main page body, resolving the issue where only cards changed color in dark mode.